### PR TITLE
remove info that json-rpc need http

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,7 +2,7 @@
 
 # What is json-rpc
 
-Is a specification that allows to call remote procedure over http with json as payload. See [JSON-RPC-Spec](https://www.jsonrpc.org/specification)
+is a json-based protocol for rpc. See [JSON-RPC-Spec](https://www.jsonrpc.org/specification).
 
 # Why still using json-rpc
 


### PR DESCRIPTION
json-rpc is technology-neutral and can be used via any existing protocol such as http, websockets plain tcp