### PR TITLE
Revert "Bump fish.payara.maven.plugins:payara-micro-maven-plugin from 2.5 to 2.5.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
                 <plugin>
                     <groupId>fish.payara.maven.plugins</groupId>
                     <artifactId>payara-micro-maven-plugin</artifactId>
-                    <version>2.5.1</version>
+                    <version>2.5</version>
                     <executions>
                         <execution>
                             <phase>package</phase>


### PR DESCRIPTION
this version of payara-micro-maven-plugin needs a lot of changes to work correctly.